### PR TITLE
Redirect user to main page after they are registered

### DIFF
--- a/login/tests.py
+++ b/login/tests.py
@@ -28,6 +28,9 @@ class TestRegistration(WebTest):
             return True
         except UserProfile.DoesNotExist:
             return False
+    
+    def check_redirect(self, redirect_url, user_id='5', username='alexander-hamilton'):
+        return redirect_url == f'/user/{user_id}/{username}/'
 
     def test_loadpage(self):
         self.app.get('/login/signup')
@@ -46,6 +49,7 @@ class TestRegistration(WebTest):
         TODO: Test that the following page is, indeed, the front page.
         '''
         res = res.follow()
+        self.assertTrue(self.check_redirect(res.url), 'User was not directed to home page on account creation')
 
     def test_duplicated_loginname_errors(self):
         self.try_signup()

--- a/login/tests.py
+++ b/login/tests.py
@@ -44,10 +44,6 @@ class TestRegistration(WebTest):
     # Check that user is redirected to front page after signup
     def test_redirect(self):
         res = self.try_signup()
-        '''
-        At the moment, only checks that it redirects at all.
-        TODO: Test that the following page is, indeed, the front page.
-        '''
         res = res.follow()
         self.assertTrue(self.check_redirect(res.url), 'User was not directed to home page on account creation')
 

--- a/login/views.py
+++ b/login/views.py
@@ -2,6 +2,7 @@ from profiles.models import UserProfile
 from django.utils.text import slugify
 from django.urls import reverse_lazy
 from django.contrib.auth.models import User
+from django.contrib.auth import login, authenticate
 from django.http import HttpResponseRedirect
 from django.views.generic.edit import FormView
 from django.db import IntegrityError, transaction
@@ -31,7 +32,7 @@ class UserProfileForm(Form):
 class SignupView(FormView):
     template_name = "login/registration.html"
     form_class = UserProfileForm
-    success_url = reverse_lazy('login')
+    success_url = '/user/'
 
     def report_error(self, form):
         return self.render_to_response(self.get_context_data(form=form))
@@ -59,5 +60,8 @@ class SignupView(FormView):
             elif 'screenname' in repr(e.__cause__):
                 form.add_error('screenname', 'Someone is already using this screenname.')
             return self.report_error(form)
+
+        user = authenticate(username=loginname, password=pwd)
+        login(self.request, user)
 
         return HttpResponseRedirect(self.get_success_url())


### PR DESCRIPTION
After a successful registration/sign-up the user is logged into the new account and redirected to the main page. A test was also written to ensure that the redirect was successful and points to the correct page.

I've considered the main page to be .../user/... given that that's what the log-in page redirects the user to.

Issue #41 